### PR TITLE
[v1] Manually migrate to assimp 5.2.5 

### DIFF
--- a/.azure-pipelines/azure-pipelines-win.yml
+++ b/.azure-pipelines/azure-pipelines-win.yml
@@ -29,6 +29,7 @@ jobs:
   timeoutInMinutes: 360
   variables:
     CONDA_BLD_PATH: D:\\bld\\
+    UPLOAD_TEMP: D:\\tmp
 
   steps:
     - task: PythonScript@0
@@ -50,7 +51,7 @@ jobs:
 
     - script: |
         call activate base
-        mamba.exe install 'python=3.9' conda-build conda pip boa 'conda-forge-ci-setup=3' -c conda-forge --strict-channel-priority --yes
+        mamba.exe install "python=3.9" conda-build conda pip boa conda-forge-ci-setup=3 "py-lief<0.12" -c conda-forge --strict-channel-priority --yes
       displayName: Install conda-build
 
     - script: set PYTHONUNBUFFERED=1
@@ -87,6 +88,9 @@ jobs:
     - script: |
         set "GIT_BRANCH=%BUILD_SOURCEBRANCHNAME%"
         set "FEEDSTOCK_NAME=%BUILD_REPOSITORY_NAME:*/=%"
+        set "TEMP=$(UPLOAD_TEMP)"
+        if not exist "%TEMP%\" md "%TEMP%"
+        set "TMP=%TEMP%"
         call activate base
         upload_package --validate --feedstock-name="%FEEDSTOCK_NAME%" .\ ".\recipe" .ci_support\%CONFIG%.yaml
       displayName: Upload package

--- a/.ci_support/linux_64_numpy1.20python3.8.____73_pypy.yaml
+++ b/.ci_support/linux_64_numpy1.20python3.8.____73_pypy.yaml
@@ -1,5 +1,5 @@
 assimp:
-- 5.2.4
+- 5.2.5
 boost:
 - 1.78.0
 cdt_name:
@@ -11,7 +11,7 @@ channel_targets:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '10'
+- '11'
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 numpy:

--- a/.ci_support/linux_64_numpy1.20python3.8.____cpython.yaml
+++ b/.ci_support/linux_64_numpy1.20python3.8.____cpython.yaml
@@ -1,5 +1,5 @@
 assimp:
-- 5.2.4
+- 5.2.5
 boost:
 - 1.78.0
 cdt_name:
@@ -11,7 +11,7 @@ channel_targets:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '10'
+- '11'
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 numpy:

--- a/.ci_support/linux_64_numpy1.20python3.9.____73_pypy.yaml
+++ b/.ci_support/linux_64_numpy1.20python3.9.____73_pypy.yaml
@@ -1,5 +1,5 @@
 assimp:
-- 5.2.4
+- 5.2.5
 boost:
 - 1.78.0
 cdt_name:
@@ -11,7 +11,7 @@ channel_targets:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '10'
+- '11'
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 numpy:

--- a/.ci_support/linux_64_numpy1.20python3.9.____cpython.yaml
+++ b/.ci_support/linux_64_numpy1.20python3.9.____cpython.yaml
@@ -1,5 +1,5 @@
 assimp:
-- 5.2.4
+- 5.2.5
 boost:
 - 1.78.0
 cdt_name:
@@ -11,7 +11,7 @@ channel_targets:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '10'
+- '11'
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 numpy:

--- a/.ci_support/linux_64_numpy1.21python3.10.____cpython.yaml
+++ b/.ci_support/linux_64_numpy1.21python3.10.____cpython.yaml
@@ -1,5 +1,5 @@
 assimp:
-- 5.2.4
+- 5.2.5
 boost:
 - 1.78.0
 cdt_name:
@@ -11,7 +11,7 @@ channel_targets:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '10'
+- '11'
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 numpy:

--- a/.ci_support/linux_64_numpy1.23python3.11.____cpython.yaml
+++ b/.ci_support/linux_64_numpy1.23python3.11.____cpython.yaml
@@ -1,5 +1,5 @@
 assimp:
-- 5.2.4
+- 5.2.5
 boost:
 - 1.78.0
 cdt_name:
@@ -11,7 +11,7 @@ channel_targets:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '10'
+- '11'
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 numpy:

--- a/.ci_support/linux_aarch64_numpy1.20python3.8.____73_pypy.yaml
+++ b/.ci_support/linux_aarch64_numpy1.20python3.8.____73_pypy.yaml
@@ -1,7 +1,7 @@
 BUILD:
 - aarch64-conda_cos7-linux-gnu
 assimp:
-- 5.2.4
+- 5.2.5
 boost:
 - 1.78.0
 cdt_arch:
@@ -15,7 +15,7 @@ channel_targets:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '10'
+- '11'
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 numpy:

--- a/.ci_support/linux_aarch64_numpy1.20python3.8.____cpython.yaml
+++ b/.ci_support/linux_aarch64_numpy1.20python3.8.____cpython.yaml
@@ -1,7 +1,7 @@
 BUILD:
 - aarch64-conda_cos7-linux-gnu
 assimp:
-- 5.2.4
+- 5.2.5
 boost:
 - 1.78.0
 cdt_arch:
@@ -15,7 +15,7 @@ channel_targets:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '10'
+- '11'
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 numpy:

--- a/.ci_support/linux_aarch64_numpy1.20python3.9.____73_pypy.yaml
+++ b/.ci_support/linux_aarch64_numpy1.20python3.9.____73_pypy.yaml
@@ -1,7 +1,7 @@
 BUILD:
 - aarch64-conda_cos7-linux-gnu
 assimp:
-- 5.2.4
+- 5.2.5
 boost:
 - 1.78.0
 cdt_arch:
@@ -15,7 +15,7 @@ channel_targets:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '10'
+- '11'
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 numpy:

--- a/.ci_support/linux_aarch64_numpy1.20python3.9.____cpython.yaml
+++ b/.ci_support/linux_aarch64_numpy1.20python3.9.____cpython.yaml
@@ -1,7 +1,7 @@
 BUILD:
 - aarch64-conda_cos7-linux-gnu
 assimp:
-- 5.2.4
+- 5.2.5
 boost:
 - 1.78.0
 cdt_arch:
@@ -15,7 +15,7 @@ channel_targets:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '10'
+- '11'
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 numpy:

--- a/.ci_support/linux_aarch64_numpy1.21python3.10.____cpython.yaml
+++ b/.ci_support/linux_aarch64_numpy1.21python3.10.____cpython.yaml
@@ -1,7 +1,7 @@
 BUILD:
 - aarch64-conda_cos7-linux-gnu
 assimp:
-- 5.2.4
+- 5.2.5
 boost:
 - 1.78.0
 cdt_arch:
@@ -15,7 +15,7 @@ channel_targets:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '10'
+- '11'
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 numpy:

--- a/.ci_support/linux_aarch64_numpy1.23python3.11.____cpython.yaml
+++ b/.ci_support/linux_aarch64_numpy1.23python3.11.____cpython.yaml
@@ -1,7 +1,7 @@
 BUILD:
 - aarch64-conda_cos7-linux-gnu
 assimp:
-- 5.2.4
+- 5.2.5
 boost:
 - 1.78.0
 cdt_arch:
@@ -15,7 +15,7 @@ channel_targets:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '10'
+- '11'
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 numpy:

--- a/.ci_support/linux_ppc64le_numpy1.20python3.8.____73_pypy.yaml
+++ b/.ci_support/linux_ppc64le_numpy1.20python3.8.____73_pypy.yaml
@@ -1,5 +1,5 @@
 assimp:
-- 5.2.4
+- 5.2.5
 boost:
 - 1.78.0
 cdt_name:
@@ -11,7 +11,7 @@ channel_targets:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '10'
+- '11'
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 numpy:

--- a/.ci_support/linux_ppc64le_numpy1.20python3.8.____cpython.yaml
+++ b/.ci_support/linux_ppc64le_numpy1.20python3.8.____cpython.yaml
@@ -1,5 +1,5 @@
 assimp:
-- 5.2.4
+- 5.2.5
 boost:
 - 1.78.0
 cdt_name:
@@ -11,7 +11,7 @@ channel_targets:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '10'
+- '11'
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 numpy:

--- a/.ci_support/linux_ppc64le_numpy1.20python3.9.____73_pypy.yaml
+++ b/.ci_support/linux_ppc64le_numpy1.20python3.9.____73_pypy.yaml
@@ -1,5 +1,5 @@
 assimp:
-- 5.2.4
+- 5.2.5
 boost:
 - 1.78.0
 cdt_name:
@@ -11,7 +11,7 @@ channel_targets:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '10'
+- '11'
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 numpy:

--- a/.ci_support/linux_ppc64le_numpy1.20python3.9.____cpython.yaml
+++ b/.ci_support/linux_ppc64le_numpy1.20python3.9.____cpython.yaml
@@ -1,5 +1,5 @@
 assimp:
-- 5.2.4
+- 5.2.5
 boost:
 - 1.78.0
 cdt_name:
@@ -11,7 +11,7 @@ channel_targets:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '10'
+- '11'
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 numpy:

--- a/.ci_support/linux_ppc64le_numpy1.21python3.10.____cpython.yaml
+++ b/.ci_support/linux_ppc64le_numpy1.21python3.10.____cpython.yaml
@@ -1,5 +1,5 @@
 assimp:
-- 5.2.4
+- 5.2.5
 boost:
 - 1.78.0
 cdt_name:
@@ -11,7 +11,7 @@ channel_targets:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '10'
+- '11'
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 numpy:

--- a/.ci_support/linux_ppc64le_numpy1.23python3.11.____cpython.yaml
+++ b/.ci_support/linux_ppc64le_numpy1.23python3.11.____cpython.yaml
@@ -1,5 +1,5 @@
 assimp:
-- 5.2.4
+- 5.2.5
 boost:
 - 1.78.0
 cdt_name:
@@ -11,7 +11,7 @@ channel_targets:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '10'
+- '11'
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 numpy:

--- a/.ci_support/migrations/assimp525.yaml
+++ b/.ci_support/migrations/assimp525.yaml
@@ -1,0 +1,7 @@
+__migrator:
+  build_number: 1
+  kind: version
+  migration_number: 1
+assimp:
+- 5.2.5
+migrator_ts: 1663100710.2627342

--- a/.ci_support/osx_64_numpy1.20python3.8.____73_pypy.yaml
+++ b/.ci_support/osx_64_numpy1.20python3.8.____73_pypy.yaml
@@ -1,7 +1,7 @@
 MACOSX_DEPLOYMENT_TARGET:
 - '10.9'
 assimp:
-- 5.2.4
+- 5.2.5
 boost:
 - 1.78.0
 channel_sources:

--- a/.ci_support/osx_64_numpy1.20python3.8.____cpython.yaml
+++ b/.ci_support/osx_64_numpy1.20python3.8.____cpython.yaml
@@ -1,7 +1,7 @@
 MACOSX_DEPLOYMENT_TARGET:
 - '10.9'
 assimp:
-- 5.2.4
+- 5.2.5
 boost:
 - 1.78.0
 channel_sources:

--- a/.ci_support/osx_64_numpy1.20python3.9.____73_pypy.yaml
+++ b/.ci_support/osx_64_numpy1.20python3.9.____73_pypy.yaml
@@ -1,7 +1,7 @@
 MACOSX_DEPLOYMENT_TARGET:
 - '10.9'
 assimp:
-- 5.2.4
+- 5.2.5
 boost:
 - 1.78.0
 channel_sources:

--- a/.ci_support/osx_64_numpy1.20python3.9.____cpython.yaml
+++ b/.ci_support/osx_64_numpy1.20python3.9.____cpython.yaml
@@ -1,7 +1,7 @@
 MACOSX_DEPLOYMENT_TARGET:
 - '10.9'
 assimp:
-- 5.2.4
+- 5.2.5
 boost:
 - 1.78.0
 channel_sources:

--- a/.ci_support/osx_64_numpy1.21python3.10.____cpython.yaml
+++ b/.ci_support/osx_64_numpy1.21python3.10.____cpython.yaml
@@ -1,7 +1,7 @@
 MACOSX_DEPLOYMENT_TARGET:
 - '10.9'
 assimp:
-- 5.2.4
+- 5.2.5
 boost:
 - 1.78.0
 channel_sources:

--- a/.ci_support/osx_64_numpy1.23python3.11.____cpython.yaml
+++ b/.ci_support/osx_64_numpy1.23python3.11.____cpython.yaml
@@ -1,7 +1,7 @@
 MACOSX_DEPLOYMENT_TARGET:
 - '10.9'
 assimp:
-- 5.2.4
+- 5.2.5
 boost:
 - 1.78.0
 channel_sources:

--- a/.ci_support/osx_arm64_numpy1.20python3.8.____cpython.yaml
+++ b/.ci_support/osx_arm64_numpy1.20python3.8.____cpython.yaml
@@ -1,7 +1,7 @@
 MACOSX_DEPLOYMENT_TARGET:
 - '11.0'
 assimp:
-- 5.2.4
+- 5.2.5
 boost:
 - 1.78.0
 channel_sources:

--- a/.ci_support/osx_arm64_numpy1.20python3.9.____cpython.yaml
+++ b/.ci_support/osx_arm64_numpy1.20python3.9.____cpython.yaml
@@ -1,7 +1,7 @@
 MACOSX_DEPLOYMENT_TARGET:
 - '11.0'
 assimp:
-- 5.2.4
+- 5.2.5
 boost:
 - 1.78.0
 channel_sources:

--- a/.ci_support/osx_arm64_numpy1.21python3.10.____cpython.yaml
+++ b/.ci_support/osx_arm64_numpy1.21python3.10.____cpython.yaml
@@ -1,7 +1,7 @@
 MACOSX_DEPLOYMENT_TARGET:
 - '11.0'
 assimp:
-- 5.2.4
+- 5.2.5
 boost:
 - 1.78.0
 channel_sources:

--- a/.ci_support/osx_arm64_numpy1.23python3.11.____cpython.yaml
+++ b/.ci_support/osx_arm64_numpy1.23python3.11.____cpython.yaml
@@ -1,7 +1,7 @@
 MACOSX_DEPLOYMENT_TARGET:
 - '11.0'
 assimp:
-- 5.2.4
+- 5.2.5
 boost:
 - 1.78.0
 channel_sources:

--- a/.ci_support/win_64_numpy1.20python3.8.____73_pypy.yaml
+++ b/.ci_support/win_64_numpy1.20python3.8.____73_pypy.yaml
@@ -1,5 +1,5 @@
 assimp:
-- 5.2.4
+- 5.2.5
 boost:
 - 1.78.0
 channel_sources:

--- a/.ci_support/win_64_numpy1.20python3.8.____cpython.yaml
+++ b/.ci_support/win_64_numpy1.20python3.8.____cpython.yaml
@@ -1,5 +1,5 @@
 assimp:
-- 5.2.4
+- 5.2.5
 boost:
 - 1.78.0
 channel_sources:

--- a/.ci_support/win_64_numpy1.20python3.9.____73_pypy.yaml
+++ b/.ci_support/win_64_numpy1.20python3.9.____73_pypy.yaml
@@ -1,5 +1,5 @@
 assimp:
-- 5.2.4
+- 5.2.5
 boost:
 - 1.78.0
 channel_sources:

--- a/.ci_support/win_64_numpy1.20python3.9.____cpython.yaml
+++ b/.ci_support/win_64_numpy1.20python3.9.____cpython.yaml
@@ -1,5 +1,5 @@
 assimp:
-- 5.2.4
+- 5.2.5
 boost:
 - 1.78.0
 channel_sources:

--- a/.ci_support/win_64_numpy1.21python3.10.____cpython.yaml
+++ b/.ci_support/win_64_numpy1.21python3.10.____cpython.yaml
@@ -1,5 +1,5 @@
 assimp:
-- 5.2.4
+- 5.2.5
 boost:
 - 1.78.0
 channel_sources:

--- a/.ci_support/win_64_numpy1.23python3.11.____cpython.yaml
+++ b/.ci_support/win_64_numpy1.23python3.11.____cpython.yaml
@@ -1,5 +1,5 @@
 assimp:
-- 5.2.4
+- 5.2.5
 boost:
 - 1.78.0
 channel_sources:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 # This file was generated automatically from conda-smithy. To update this configuration,
 # update the conda-forge.yml and/or the recipe/meta.yaml.
-# -*- mode: yaml -*-
+# -*- mode: jinja-yaml -*-
 
 version: 2
 

--- a/.scripts/build_steps.sh
+++ b/.scripts/build_steps.sh
@@ -33,9 +33,9 @@ CONDARC
 
 
 mamba install --update-specs --yes --quiet --channel conda-forge \
-    conda-build pip boa conda-forge-ci-setup=3
+    conda-build pip boa conda-forge-ci-setup=3 "py-lief<0.12"
 mamba update --update-specs --yes --quiet --channel conda-forge \
-    conda-build pip boa conda-forge-ci-setup=3
+    conda-build pip boa conda-forge-ci-setup=3 "py-lief<0.12"
 
 # set up the condarc
 setup_conda_rc "${FEEDSTOCK_ROOT}" "${RECIPE_ROOT}" "${CONFIG_FILE}"

--- a/.scripts/run_osx_build.sh
+++ b/.scripts/run_osx_build.sh
@@ -23,11 +23,10 @@ bash $MINIFORGE_FILE -b -p ${MINIFORGE_HOME}
 source ${MINIFORGE_HOME}/etc/profile.d/conda.sh
 conda activate base
 
-echo -e "\n\nInstalling ['conda-forge-ci-setup=3'] and conda-build."
 mamba install --update-specs --quiet --yes --channel conda-forge \
-    conda-build pip boa conda-forge-ci-setup=3
+    conda-build pip boa conda-forge-ci-setup=3 "py-lief<0.12"
 mamba update --update-specs --yes --quiet --channel conda-forge \
-    conda-build pip boa conda-forge-ci-setup=3
+    conda-build pip boa conda-forge-ci-setup=3 "py-lief<0.12"
 
 
 

--- a/README.md
+++ b/README.md
@@ -32,238 +32,238 @@ Current build status
               <td>linux_64_numpy1.20python3.8.____73_pypy</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=7388&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/hpp-fcl-feedstock?branchName=main&jobName=linux&configuration=linux_64_numpy1.20python3.8.____73_pypy" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/hpp-fcl-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_numpy1.20python3.8.____73_pypy" alt="variant">
                 </a>
               </td>
             </tr><tr>
               <td>linux_64_numpy1.20python3.8.____cpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=7388&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/hpp-fcl-feedstock?branchName=main&jobName=linux&configuration=linux_64_numpy1.20python3.8.____cpython" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/hpp-fcl-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_numpy1.20python3.8.____cpython" alt="variant">
                 </a>
               </td>
             </tr><tr>
               <td>linux_64_numpy1.20python3.9.____73_pypy</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=7388&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/hpp-fcl-feedstock?branchName=main&jobName=linux&configuration=linux_64_numpy1.20python3.9.____73_pypy" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/hpp-fcl-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_numpy1.20python3.9.____73_pypy" alt="variant">
                 </a>
               </td>
             </tr><tr>
               <td>linux_64_numpy1.20python3.9.____cpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=7388&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/hpp-fcl-feedstock?branchName=main&jobName=linux&configuration=linux_64_numpy1.20python3.9.____cpython" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/hpp-fcl-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_numpy1.20python3.9.____cpython" alt="variant">
                 </a>
               </td>
             </tr><tr>
               <td>linux_64_numpy1.21python3.10.____cpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=7388&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/hpp-fcl-feedstock?branchName=main&jobName=linux&configuration=linux_64_numpy1.21python3.10.____cpython" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/hpp-fcl-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_numpy1.21python3.10.____cpython" alt="variant">
                 </a>
               </td>
             </tr><tr>
               <td>linux_64_numpy1.23python3.11.____cpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=7388&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/hpp-fcl-feedstock?branchName=main&jobName=linux&configuration=linux_64_numpy1.23python3.11.____cpython" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/hpp-fcl-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_numpy1.23python3.11.____cpython" alt="variant">
                 </a>
               </td>
             </tr><tr>
               <td>linux_aarch64_numpy1.20python3.8.____73_pypy</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=7388&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/hpp-fcl-feedstock?branchName=main&jobName=linux&configuration=linux_aarch64_numpy1.20python3.8.____73_pypy" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/hpp-fcl-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_aarch64_numpy1.20python3.8.____73_pypy" alt="variant">
                 </a>
               </td>
             </tr><tr>
               <td>linux_aarch64_numpy1.20python3.8.____cpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=7388&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/hpp-fcl-feedstock?branchName=main&jobName=linux&configuration=linux_aarch64_numpy1.20python3.8.____cpython" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/hpp-fcl-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_aarch64_numpy1.20python3.8.____cpython" alt="variant">
                 </a>
               </td>
             </tr><tr>
               <td>linux_aarch64_numpy1.20python3.9.____73_pypy</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=7388&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/hpp-fcl-feedstock?branchName=main&jobName=linux&configuration=linux_aarch64_numpy1.20python3.9.____73_pypy" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/hpp-fcl-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_aarch64_numpy1.20python3.9.____73_pypy" alt="variant">
                 </a>
               </td>
             </tr><tr>
               <td>linux_aarch64_numpy1.20python3.9.____cpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=7388&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/hpp-fcl-feedstock?branchName=main&jobName=linux&configuration=linux_aarch64_numpy1.20python3.9.____cpython" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/hpp-fcl-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_aarch64_numpy1.20python3.9.____cpython" alt="variant">
                 </a>
               </td>
             </tr><tr>
               <td>linux_aarch64_numpy1.21python3.10.____cpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=7388&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/hpp-fcl-feedstock?branchName=main&jobName=linux&configuration=linux_aarch64_numpy1.21python3.10.____cpython" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/hpp-fcl-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_aarch64_numpy1.21python3.10.____cpython" alt="variant">
                 </a>
               </td>
             </tr><tr>
               <td>linux_aarch64_numpy1.23python3.11.____cpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=7388&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/hpp-fcl-feedstock?branchName=main&jobName=linux&configuration=linux_aarch64_numpy1.23python3.11.____cpython" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/hpp-fcl-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_aarch64_numpy1.23python3.11.____cpython" alt="variant">
                 </a>
               </td>
             </tr><tr>
               <td>linux_ppc64le_numpy1.20python3.8.____73_pypy</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=7388&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/hpp-fcl-feedstock?branchName=main&jobName=linux&configuration=linux_ppc64le_numpy1.20python3.8.____73_pypy" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/hpp-fcl-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_ppc64le_numpy1.20python3.8.____73_pypy" alt="variant">
                 </a>
               </td>
             </tr><tr>
               <td>linux_ppc64le_numpy1.20python3.8.____cpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=7388&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/hpp-fcl-feedstock?branchName=main&jobName=linux&configuration=linux_ppc64le_numpy1.20python3.8.____cpython" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/hpp-fcl-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_ppc64le_numpy1.20python3.8.____cpython" alt="variant">
                 </a>
               </td>
             </tr><tr>
               <td>linux_ppc64le_numpy1.20python3.9.____73_pypy</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=7388&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/hpp-fcl-feedstock?branchName=main&jobName=linux&configuration=linux_ppc64le_numpy1.20python3.9.____73_pypy" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/hpp-fcl-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_ppc64le_numpy1.20python3.9.____73_pypy" alt="variant">
                 </a>
               </td>
             </tr><tr>
               <td>linux_ppc64le_numpy1.20python3.9.____cpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=7388&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/hpp-fcl-feedstock?branchName=main&jobName=linux&configuration=linux_ppc64le_numpy1.20python3.9.____cpython" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/hpp-fcl-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_ppc64le_numpy1.20python3.9.____cpython" alt="variant">
                 </a>
               </td>
             </tr><tr>
               <td>linux_ppc64le_numpy1.21python3.10.____cpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=7388&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/hpp-fcl-feedstock?branchName=main&jobName=linux&configuration=linux_ppc64le_numpy1.21python3.10.____cpython" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/hpp-fcl-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_ppc64le_numpy1.21python3.10.____cpython" alt="variant">
                 </a>
               </td>
             </tr><tr>
               <td>linux_ppc64le_numpy1.23python3.11.____cpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=7388&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/hpp-fcl-feedstock?branchName=main&jobName=linux&configuration=linux_ppc64le_numpy1.23python3.11.____cpython" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/hpp-fcl-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_ppc64le_numpy1.23python3.11.____cpython" alt="variant">
                 </a>
               </td>
             </tr><tr>
               <td>osx_64_numpy1.20python3.8.____73_pypy</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=7388&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/hpp-fcl-feedstock?branchName=main&jobName=osx&configuration=osx_64_numpy1.20python3.8.____73_pypy" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/hpp-fcl-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_numpy1.20python3.8.____73_pypy" alt="variant">
                 </a>
               </td>
             </tr><tr>
               <td>osx_64_numpy1.20python3.8.____cpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=7388&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/hpp-fcl-feedstock?branchName=main&jobName=osx&configuration=osx_64_numpy1.20python3.8.____cpython" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/hpp-fcl-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_numpy1.20python3.8.____cpython" alt="variant">
                 </a>
               </td>
             </tr><tr>
               <td>osx_64_numpy1.20python3.9.____73_pypy</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=7388&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/hpp-fcl-feedstock?branchName=main&jobName=osx&configuration=osx_64_numpy1.20python3.9.____73_pypy" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/hpp-fcl-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_numpy1.20python3.9.____73_pypy" alt="variant">
                 </a>
               </td>
             </tr><tr>
               <td>osx_64_numpy1.20python3.9.____cpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=7388&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/hpp-fcl-feedstock?branchName=main&jobName=osx&configuration=osx_64_numpy1.20python3.9.____cpython" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/hpp-fcl-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_numpy1.20python3.9.____cpython" alt="variant">
                 </a>
               </td>
             </tr><tr>
               <td>osx_64_numpy1.21python3.10.____cpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=7388&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/hpp-fcl-feedstock?branchName=main&jobName=osx&configuration=osx_64_numpy1.21python3.10.____cpython" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/hpp-fcl-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_numpy1.21python3.10.____cpython" alt="variant">
                 </a>
               </td>
             </tr><tr>
               <td>osx_64_numpy1.23python3.11.____cpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=7388&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/hpp-fcl-feedstock?branchName=main&jobName=osx&configuration=osx_64_numpy1.23python3.11.____cpython" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/hpp-fcl-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_numpy1.23python3.11.____cpython" alt="variant">
                 </a>
               </td>
             </tr><tr>
               <td>osx_arm64_numpy1.20python3.8.____cpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=7388&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/hpp-fcl-feedstock?branchName=main&jobName=osx&configuration=osx_arm64_numpy1.20python3.8.____cpython" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/hpp-fcl-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_arm64_numpy1.20python3.8.____cpython" alt="variant">
                 </a>
               </td>
             </tr><tr>
               <td>osx_arm64_numpy1.20python3.9.____cpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=7388&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/hpp-fcl-feedstock?branchName=main&jobName=osx&configuration=osx_arm64_numpy1.20python3.9.____cpython" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/hpp-fcl-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_arm64_numpy1.20python3.9.____cpython" alt="variant">
                 </a>
               </td>
             </tr><tr>
               <td>osx_arm64_numpy1.21python3.10.____cpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=7388&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/hpp-fcl-feedstock?branchName=main&jobName=osx&configuration=osx_arm64_numpy1.21python3.10.____cpython" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/hpp-fcl-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_arm64_numpy1.21python3.10.____cpython" alt="variant">
                 </a>
               </td>
             </tr><tr>
               <td>osx_arm64_numpy1.23python3.11.____cpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=7388&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/hpp-fcl-feedstock?branchName=main&jobName=osx&configuration=osx_arm64_numpy1.23python3.11.____cpython" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/hpp-fcl-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_arm64_numpy1.23python3.11.____cpython" alt="variant">
                 </a>
               </td>
             </tr><tr>
               <td>win_64_numpy1.20python3.8.____73_pypy</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=7388&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/hpp-fcl-feedstock?branchName=main&jobName=win&configuration=win_64_numpy1.20python3.8.____73_pypy" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/hpp-fcl-feedstock?branchName=main&jobName=win&configuration=win%20win_64_numpy1.20python3.8.____73_pypy" alt="variant">
                 </a>
               </td>
             </tr><tr>
               <td>win_64_numpy1.20python3.8.____cpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=7388&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/hpp-fcl-feedstock?branchName=main&jobName=win&configuration=win_64_numpy1.20python3.8.____cpython" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/hpp-fcl-feedstock?branchName=main&jobName=win&configuration=win%20win_64_numpy1.20python3.8.____cpython" alt="variant">
                 </a>
               </td>
             </tr><tr>
               <td>win_64_numpy1.20python3.9.____73_pypy</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=7388&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/hpp-fcl-feedstock?branchName=main&jobName=win&configuration=win_64_numpy1.20python3.9.____73_pypy" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/hpp-fcl-feedstock?branchName=main&jobName=win&configuration=win%20win_64_numpy1.20python3.9.____73_pypy" alt="variant">
                 </a>
               </td>
             </tr><tr>
               <td>win_64_numpy1.20python3.9.____cpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=7388&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/hpp-fcl-feedstock?branchName=main&jobName=win&configuration=win_64_numpy1.20python3.9.____cpython" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/hpp-fcl-feedstock?branchName=main&jobName=win&configuration=win%20win_64_numpy1.20python3.9.____cpython" alt="variant">
                 </a>
               </td>
             </tr><tr>
               <td>win_64_numpy1.21python3.10.____cpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=7388&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/hpp-fcl-feedstock?branchName=main&jobName=win&configuration=win_64_numpy1.21python3.10.____cpython" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/hpp-fcl-feedstock?branchName=main&jobName=win&configuration=win%20win_64_numpy1.21python3.10.____cpython" alt="variant">
                 </a>
               </td>
             </tr><tr>
               <td>win_64_numpy1.23python3.11.____cpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=7388&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/hpp-fcl-feedstock?branchName=main&jobName=win&configuration=win_64_numpy1.23python3.11.____cpython" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/hpp-fcl-feedstock?branchName=main&jobName=win&configuration=win%20win_64_numpy1.23python3.11.____cpython" alt="variant">
                 </a>
               </td>
             </tr>

--- a/recipe/fixassimpwin0.patch
+++ b/recipe/fixassimpwin0.patch
@@ -1,0 +1,84 @@
+diff --git a/cmake-modules/Findassimp.cmake b/cmake-modules/Findassimp.cmake
+index 6c323ada..db98c00a 100644
+--- a/cmake-modules/Findassimp.cmake
++++ b/cmake-modules/Findassimp.cmake
+@@ -3,7 +3,7 @@ if(CMAKE_SIZEOF_VOID_P EQUAL 8)
+ elseif(CMAKE_SIZEOF_VOID_P EQUAL 4)
+ 	set(ASSIMP_ARCHITECTURE "32")
+ endif(CMAKE_SIZEOF_VOID_P EQUAL 8)
+-	
++
+ if(WIN32)
+ 	set(ASSIMP_ROOT_DIR CACHE PATH "ASSIMP root directory")
+ 
+@@ -18,12 +18,12 @@ if(WIN32)
+ 
+ 	if(MSVC12)
+ 		set(ASSIMP_MSVC_VERSIONS "vc120")
+-	elseif(MSVC14)	
++	elseif(MSVC14)
+ 		set(ASSIMP_MSVC_VERSIONS "vc140;vc141")
+ 	endif(MSVC12)
+-	
++
+ 	if(MSVC12 OR MSVC14)
+-	
++
+     foreach(ASSIMP_MSVC_VERSION ${ASSIMP_MSVC_VERSIONS})
+       find_path(ASSIMP_LIBRARY_DIR
+         NAMES
+@@ -32,27 +32,27 @@ if(WIN32)
+         HINTS
+           ${ASSIMP_ROOT_DIR}/lib${ASSIMP_ARCHITECTURE}
+       )
+-      
++
+       find_library(ASSIMP_LIBRARY_RELEASE				assimp-${ASSIMP_MSVC_VERSION}-mt.lib 			PATHS ${ASSIMP_LIBRARY_DIR})
+       find_library(ASSIMP_LIBRARY_DEBUG				assimp-${ASSIMP_MSVC_VERSION}-mtd.lib			PATHS ${ASSIMP_LIBRARY_DIR})
+ 
+       IF(NOT ASSIMP_LIBRARY_RELEASE AND NOT ASSIMP_LIBRARY_DEBUG)
+         continue()
+       ENDIF()
+-      
++
+       IF(ASSIMP_LIBRARY_DEBUG)
+-        set(ASSIMP_LIBRARY 
++        set(ASSIMP_LIBRARY
+           optimized 	${ASSIMP_LIBRARY_RELEASE}
+           debug		${ASSIMP_LIBRARY_DEBUG}
+         )
+       ELSE()
+-        set(ASSIMP_LIBRARY 
++        set(ASSIMP_LIBRARY
+           optimized 	${ASSIMP_LIBRARY_RELEASE}
+         )
+       ENDIF()
+-      
++
+       set(ASSIMP_LIBRARIES ${ASSIMP_LIBRARY_RELEASE} ${ASSIMP_LIBRARY_DEBUG})
+-    
++
+       FUNCTION(ASSIMP_COPY_BINARIES TargetDirectory)
+         ADD_CUSTOM_TARGET(AssimpCopyBinaries
+           COMMAND ${CMAKE_COMMAND} -E copy ${ASSIMP_ROOT_DIR}/bin${ASSIMP_ARCHITECTURE}/assimp-${ASSIMP_MSVC_VERSION}-mtd.dll 	${TargetDirectory}/Debug/assimp-${ASSIMP_MSVC_VERSION}-mtd.dll
+@@ -60,11 +60,11 @@ if(WIN32)
+         COMMENT "Copying Assimp binaries to '${TargetDirectory}'"
+         VERBATIM)
+       ENDFUNCTION(ASSIMP_COPY_BINARIES)
+-    
++
+       SET(assimp_LIBRARIES ${ASSIMP_LIBRARY})
+     endforeach()
+ 	endif()
+-	
++
+ else(WIN32)
+ 
+ 	find_path(
+@@ -96,5 +96,5 @@ else(WIN32)
+ 		message(FATAL_ERROR "Could not find asset importer library")
+ 	  endif (assimp_FIND_REQUIRED)
+ 	endif (assimp_FOUND)
+-	
++
+ endif(WIN32)

--- a/recipe/fixassimpwin1.patch
+++ b/recipe/fixassimpwin1.patch
@@ -1,0 +1,19 @@
+diff --git a/cmake-modules/Findassimp.cmake b/cmake-modules/Findassimp.cmake
+index db98c00a..8b7cefd0 100644
+--- a/cmake-modules/Findassimp.cmake
++++ b/cmake-modules/Findassimp.cmake
+@@ -18,11 +18,11 @@ if(WIN32)
+ 
+ 	if(MSVC12)
+ 		set(ASSIMP_MSVC_VERSIONS "vc120")
+-	elseif(MSVC14)
+-		set(ASSIMP_MSVC_VERSIONS "vc140;vc141")
++	else()
++		set(ASSIMP_MSVC_VERSIONS "vc140;vc141;vc142;vc143")
+ 	endif(MSVC12)
+ 
+-	if(MSVC12 OR MSVC14)
++	if(MSVC)
+ 
+     foreach(ASSIMP_MSVC_VERSION ${ASSIMP_MSVC_VERSIONS})
+       find_path(ASSIMP_LIBRARY_DIR

--- a/recipe/fixassimpwin2.patch
+++ b/recipe/fixassimpwin2.patch
@@ -1,0 +1,125 @@
+diff --git a/cmake-modules/Findassimp.cmake b/cmake-modules/Findassimp.cmake
+index 8b7cefd0..0b3dba21 100644
+--- a/cmake-modules/Findassimp.cmake
++++ b/cmake-modules/Findassimp.cmake
+@@ -4,8 +4,8 @@ elseif(CMAKE_SIZEOF_VOID_P EQUAL 4)
+ 	set(ASSIMP_ARCHITECTURE "32")
+ endif(CMAKE_SIZEOF_VOID_P EQUAL 8)
+ 
++set(ASSIMP_ROOT_DIR CACHE PATH "ASSIMP root directory")
+ if(WIN32)
+-	set(ASSIMP_ROOT_DIR CACHE PATH "ASSIMP root directory")
+ 
+ 	# Find path of each library
+ 	find_path(ASSIMP_INCLUDE_DIR
+@@ -14,7 +14,7 @@ if(WIN32)
+ 		HINTS
+ 			${ASSIMP_ROOT_DIR}/include
+ 	)
+-  SET(assimp_INCLUDE_DIRS ${ASSIMP_INCLUDE_DIR})
++  	SET(assimp_INCLUDE_DIRS ${ASSIMP_INCLUDE_DIR})
+ 
+ 	if(MSVC12)
+ 		set(ASSIMP_MSVC_VERSIONS "vc120")
+@@ -24,45 +24,53 @@ if(WIN32)
+ 
+ 	if(MSVC)
+ 
+-    foreach(ASSIMP_MSVC_VERSION ${ASSIMP_MSVC_VERSIONS})
+-      find_path(ASSIMP_LIBRARY_DIR
+-        NAMES
+-          assimp-${ASSIMP_MSVC_VERSION}-mt.lib
+-          assimp-${ASSIMP_MSVC_VERSION}-mtd.lib
+-        HINTS
+-          ${ASSIMP_ROOT_DIR}/lib${ASSIMP_ARCHITECTURE}
+-      )
+-
+-      find_library(ASSIMP_LIBRARY_RELEASE				assimp-${ASSIMP_MSVC_VERSION}-mt.lib 			PATHS ${ASSIMP_LIBRARY_DIR})
+-      find_library(ASSIMP_LIBRARY_DEBUG				assimp-${ASSIMP_MSVC_VERSION}-mtd.lib			PATHS ${ASSIMP_LIBRARY_DIR})
+-
+-      IF(NOT ASSIMP_LIBRARY_RELEASE AND NOT ASSIMP_LIBRARY_DEBUG)
+-        continue()
+-      ENDIF()
+-
+-      IF(ASSIMP_LIBRARY_DEBUG)
+-        set(ASSIMP_LIBRARY
+-          optimized 	${ASSIMP_LIBRARY_RELEASE}
+-          debug		${ASSIMP_LIBRARY_DEBUG}
+-        )
+-      ELSE()
+-        set(ASSIMP_LIBRARY
+-          optimized 	${ASSIMP_LIBRARY_RELEASE}
+-        )
+-      ENDIF()
+-
+-      set(ASSIMP_LIBRARIES ${ASSIMP_LIBRARY_RELEASE} ${ASSIMP_LIBRARY_DEBUG})
+-
+-      FUNCTION(ASSIMP_COPY_BINARIES TargetDirectory)
+-        ADD_CUSTOM_TARGET(AssimpCopyBinaries
+-          COMMAND ${CMAKE_COMMAND} -E copy ${ASSIMP_ROOT_DIR}/bin${ASSIMP_ARCHITECTURE}/assimp-${ASSIMP_MSVC_VERSION}-mtd.dll 	${TargetDirectory}/Debug/assimp-${ASSIMP_MSVC_VERSION}-mtd.dll
+-          COMMAND ${CMAKE_COMMAND} -E copy ${ASSIMP_ROOT_DIR}/bin${ASSIMP_ARCHITECTURE}/assimp-${ASSIMP_MSVC_VERSION}-mt.dll 		${TargetDirectory}/Release/assimp-${ASSIMP_MSVC_VERSION}-mt.dll
+-        COMMENT "Copying Assimp binaries to '${TargetDirectory}'"
+-        VERBATIM)
+-      ENDFUNCTION(ASSIMP_COPY_BINARIES)
+-
+-      SET(assimp_LIBRARIES ${ASSIMP_LIBRARY})
+-    endforeach()
++		find_path(ASSIMP_LIBRARY_DIR
++			NAMES
++			assimp.lib
++			assimpd.lib
++			HINTS
++			${ASSIMP_ROOT_DIR}/lib${ASSIMP_ARCHITECTURE}
++		)
++
++		find_library(ASSIMP_LIBRARY_RELEASE assimp.lib PATHS ${ASSIMP_LIBRARY_DIR})
++		find_library(ASSIMP_LIBRARY_DEBUG assimpd.lib PATHS ${ASSIMP_LIBRARY_DIR})
++
++		IF(NOT ASSIMP_LIBRARY_RELEASE AND NOT ASSIMP_LIBRARY_DEBUG)
++			foreach(ASSIMP_MSVC_VERSION ${ASSIMP_MSVC_VERSIONS})
++				find_path(ASSIMP_LIBRARY_DIR
++					NAMES
++					assimp-${ASSIMP_MSVC_VERSION}-mt.lib
++					assimp-${ASSIMP_MSVC_VERSION}-mtd.lib
++					HINTS
++					${ASSIMP_ROOT_DIR}/lib${ASSIMP_ARCHITECTURE}
++				)
++
++				find_library(ASSIMP_LIBRARY_RELEASE				assimp-${ASSIMP_MSVC_VERSION}-mt.lib 			PATHS ${ASSIMP_LIBRARY_DIR})
++				find_library(ASSIMP_LIBRARY_DEBUG				assimp-${ASSIMP_MSVC_VERSION}-mtd.lib			PATHS ${ASSIMP_LIBRARY_DIR})
++
++				IF(ASSIMP_LIBRARY_RELEASE OR ASSIMP_LIBRARY_DEBUG)
++					break()
++				ENDIF()
++			endforeach()
++		ENDIF(NOT ASSIMP_LIBRARY_RELEASE AND NOT ASSIMP_LIBRARY_DEBUG)
++
++		IF(NOT ASSIMP_LIBRARY_RELEASE AND NOT ASSIMP_LIBRARY_DEBUG)
++			SET(assimp_FOUND FALSE)
++			return()
++		ENDIF()
++
++		IF(ASSIMP_LIBRARY_DEBUG)
++			set(ASSIMP_LIBRARY
++			optimized 	${ASSIMP_LIBRARY_RELEASE}
++			debug		${ASSIMP_LIBRARY_DEBUG}
++			)
++		ELSE()
++			set(ASSIMP_LIBRARY
++			optimized 	${ASSIMP_LIBRARY_RELEASE}
++			)
++		ENDIF()
++
++		SET(assimp_LIBRARIES ${ASSIMP_LIBRARY})
+ 	endif()
+ 
+ else(WIN32)
+@@ -72,7 +80,7 @@ else(WIN32)
+ 	  NAMES assimp/postprocess.h assimp/scene.h assimp/version.h assimp/config.h assimp/cimport.h
+ 	  PATHS /usr/local/include
+ 	  PATHS /usr/include/
+-
++		HINTS	${ASSIMP_ROOT_DIR}/include
+ 	)
+ 
+ 	find_library(

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 2e399443ed49573c613bde4e295645e2bc0b449ad64565309dbbf1c08918085c
 
 build:
-  number: 3
+  number: 4
   run_exports:
     - {{ pin_subpackage(name, max_pin='x.x') }}
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -8,6 +8,10 @@ package:
 source:
   url: https://github.com/humanoid-path-planner/{{ name }}/releases/download/v{{ version }}/hpp-fcl-{{ version }}.tar.gz
   sha256: 2e399443ed49573c613bde4e295645e2bc0b449ad64565309dbbf1c08918085c
+  patches:
+    - fixassimpwin0.patch
+    - fixassimpwin1.patch
+    - fixassimpwin2.patch
 
 build:
   number: 4


### PR DESCRIPTION
I am not sure why, but even if the `v1` branch is listed in the abi migration branches, there was no assimp 5.2.5 migration. So with this PR I manually migrate the repo, to unblock https://github.com/conda-forge/hpp-pinocchio-feedstock/pull/18 and the rest of the assimp 5.2.5 migraiton.

Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
